### PR TITLE
Enable weighted RPC steering in test config

### DIFF
--- a/node/resources/tests/full_config.toml
+++ b/node/resources/tests/full_config.toml
@@ -48,26 +48,26 @@ ingestor = "index_0"
 [chains.mainnet]
 shard = "primary"
 provider = [
-  { label = "mainnet-0", url = "http://rpc.mainnet.io", features = ["archive", "traces"], weight = 1 },
-  { label = "mainnet-1", details = { type = "web3call", url = "http://rpc.mainnet.io", features = ["archive", "traces"] }, weight = 2 },
-  { label = "firehose", details = { type = "firehose", url = "http://localhost:9000", features = [] }, weight = 3 },
-  { label = "substreams", details = { type = "substreams", url = "http://localhost:9000", features = [] }, weight = 4 },
+  { label = "mainnet-0", url = "http://rpc.mainnet.io", features = ["archive", "traces"], weight = 0.1 },
+  { label = "mainnet-1", details = { type = "web3call", url = "http://rpc.mainnet.io", features = ["archive", "traces"] }, weight = 0.2 },
+  { label = "firehose", details = { type = "firehose", url = "http://localhost:9000", features = [] }, weight = 0.3 },
+  { label = "substreams", details = { type = "substreams", url = "http://localhost:9000", features = [] }, weight = 0.4 },
 ]
 
 [chains.ropsten]
 shard = "primary"
 provider = [
-  { label = "ropsten-0", url = "http://rpc.ropsten.io", transport = "rpc", features = ["archive", "traces"], weight = 1 }
+  { label = "ropsten-0", url = "http://rpc.ropsten.io", transport = "rpc", features = ["archive", "traces"], weight = 1.0 }
 ]
 
 [chains.goerli]
 shard = "primary"
 provider = [
-  { label = "goerli-0", url = "http://rpc.goerli.io", transport = "ipc", features = ["archive"], weight = 1 }
+  { label = "goerli-0", url = "http://rpc.goerli.io", transport = "ipc", features = ["archive"], weight = 1.0 }
 ]
 
 [chains.kovan]
 shard = "primary"
 provider = [
-  { label = "kovan-0", url = "http://rpc.kovan.io", transport = "ws", features = [], weight = 1 }
+  { label = "kovan-0", url = "http://rpc.kovan.io", transport = "ws", features = [], weight = 1.0 }
 ]

--- a/node/resources/tests/full_config.toml
+++ b/node/resources/tests/full_config.toml
@@ -1,3 +1,5 @@
+weighted_rpc_steering = true
+
 [general]
 query = "query_node_.*"
 
@@ -46,26 +48,26 @@ ingestor = "index_0"
 [chains.mainnet]
 shard = "primary"
 provider = [
-  { label = "mainnet-0", url = "http://rpc.mainnet.io", features = ["archive", "traces"] },
-  { label = "mainnet-1", details = { type = "web3call", url = "http://rpc.mainnet.io", features = ["archive", "traces"] }},
-  { label = "firehose", details = { type = "firehose", url = "http://localhost:9000", features = [] }},
-  { label = "substreams", details = { type = "substreams", url = "http://localhost:9000", features = [] }},
+  { label = "mainnet-0", url = "http://rpc.mainnet.io", features = ["archive", "traces"], weight = 1 },
+  { label = "mainnet-1", details = { type = "web3call", url = "http://rpc.mainnet.io", features = ["archive", "traces"] }, weight = 2 },
+  { label = "firehose", details = { type = "firehose", url = "http://localhost:9000", features = [] }, weight = 3 },
+  { label = "substreams", details = { type = "substreams", url = "http://localhost:9000", features = [] }, weight = 4 },
 ]
 
 [chains.ropsten]
 shard = "primary"
 provider = [
-  { label = "ropsten-0", url = "http://rpc.ropsten.io", transport = "rpc", features = ["archive", "traces"] }
+  { label = "ropsten-0", url = "http://rpc.ropsten.io", transport = "rpc", features = ["archive", "traces"], weight = 1 }
 ]
 
 [chains.goerli]
 shard = "primary"
 provider = [
-  { label = "goerli-0", url = "http://rpc.goerli.io", transport = "ipc", features = ["archive"] }
+  { label = "goerli-0", url = "http://rpc.goerli.io", transport = "ipc", features = ["archive"], weight = 1 }
 ]
 
 [chains.kovan]
 shard = "primary"
 provider = [
-  { label = "kovan-0", url = "http://rpc.kovan.io", transport = "ws", features = [] }
+  { label = "kovan-0", url = "http://rpc.kovan.io", transport = "ws", features = [], weight = 1 }
 ]


### PR DESCRIPTION
## Summary
- enable weighted RPC steering in test configuration
- add explicit weight field to all chain providers

## Testing
- `cargo test -p graph-node it_works_on_standard_config` *(fails: Failed to compile Firehose proto(s): google/protobuf/any.proto: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e36c15648331b0d7930fb400b1b0