### PR TITLE
feat: track subgraph sync task queue depth

### DIFF
--- a/core/src/polling_monitor/mod.rs
+++ b/core/src/polling_monitor/mod.rs
@@ -16,7 +16,7 @@ use graph::futures03::stream::StreamExt;
 use graph::futures03::{stream, Future, FutureExt, TryFutureExt};
 use graph::parking_lot::Mutex;
 use graph::prelude::tokio;
-use graph::prometheus::{Counter, Gauge};
+use graph::prometheus::{register, Counter, Gauge};
 use graph::slog::{debug, Logger};
 use graph::util::monitored::MonitoredVecDeque as VecDeque;
 use tokio::sync::{mpsc, watch};
@@ -29,6 +29,22 @@ pub use arweave_service::{arweave_service, ArweaveService};
 pub use ipfs_service::{ipfs_service, IpfsService};
 
 const MIN_BACKOFF: Duration = Duration::from_secs(5);
+
+use graph::prelude::lazy_static;
+
+lazy_static! {
+    /// Tracks the number of pending subgraph sync tasks.
+    pub static ref SUBGRAPH_SYNC_TASK_QUEUE_DEPTH: Gauge = {
+        let gauge = Gauge::new(
+            "subgraph_sync_task_queue_depth",
+            "Number of subgraph sync tasks waiting to be processed",
+        )
+        .expect("failed to create subgraph_sync_task_queue_depth gauge");
+        register(Box::new(gauge.clone()))
+            .expect("failed to register subgraph_sync_task_queue_depth gauge");
+        gauge
+    };
+}
 
 struct Backoffs<ID> {
     backoff_maker: ExponentialBackoffMaker,
@@ -77,17 +93,23 @@ impl<T> Queue<T> {
     }
 
     fn push_back(&self, e: T) {
+        SUBGRAPH_SYNC_TASK_QUEUE_DEPTH.inc();
         self.queue.lock().push_back(e);
         let _ = self.waker.send(());
     }
 
     fn push_front(&self, e: T) {
+        SUBGRAPH_SYNC_TASK_QUEUE_DEPTH.inc();
         self.queue.lock().push_front(e);
         let _ = self.waker.send(());
     }
 
     fn pop_front(&self) -> Option<T> {
-        self.queue.lock().pop_front()
+        let item = self.queue.lock().pop_front();
+        if item.is_some() {
+            SUBGRAPH_SYNC_TASK_QUEUE_DEPTH.dec();
+        }
+        item
     }
 }
 

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -27,6 +27,7 @@ use graph::prelude::{
 use graph::tokio_retry::Retry;
 use graph::util::futures::retry_strategy;
 use graph::util::futures::RETRY_DEFAULT_LIMIT;
+use crate::polling_monitor::SUBGRAPH_SYNC_TASK_QUEUE_DEPTH;
 
 pub struct SubgraphRegistrar<P, S, SM> {
     logger: Logger,
@@ -237,8 +238,12 @@ where
                     let sender = sender.clone();
                     let logger = logger.clone();
 
+                    SUBGRAPH_SYNC_TASK_QUEUE_DEPTH.inc();
                     graph::spawn(
-                        start_subgraph(id, provider.clone(), logger).map(move |()| drop(sender)),
+                        start_subgraph(id, provider.clone(), logger).map(move |()| {
+                            SUBGRAPH_SYNC_TASK_QUEUE_DEPTH.dec();
+                            drop(sender)
+                        }),
                     );
                 }
                 drop(sender);
@@ -452,7 +457,9 @@ async fn handle_assignment_event(
             deployment,
             node_id: _,
         } => {
+            SUBGRAPH_SYNC_TASK_QUEUE_DEPTH.inc();
             start_subgraph(deployment, provider.clone(), logger).await;
+            SUBGRAPH_SYNC_TASK_QUEUE_DEPTH.dec();
             Ok(())
         }
         AssignmentEvent::Remove {

--- a/docker/prometheus/alerts.yml
+++ b/docker/prometheus/alerts.yml
@@ -1,0 +1,13 @@
+groups:
+  - name: SubgraphSyncTasks
+    rules:
+      - alert: SubgraphSyncTaskQueueEmpty
+        expr: subgraph_sync_task_queue_depth == 0 and sum(deployment_synced == 0) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Subgraph sync task queue is empty while deployments remain unsynced"
+          description: |
+            The subgraph sync task queue has no pending tasks, but there are
+            deployments that have not yet completed syncing.


### PR DESCRIPTION
## Summary
- add `subgraph_sync_task_queue_depth` gauge and hook queue operations
- track deployment scheduling in registrar and expose alert rule

## Testing
- `cargo test -p graph-core` *(fails: Failed to compile Firehose proto(s): google/protobuf/any.proto: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899495ba9408331a269f4b1309e40e9